### PR TITLE
feat: allow configuration of additional annotations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,9 +36,11 @@ resource "google_cloud_run_service" "submit" {
       service_account_name = google_service_account.submit.account_id
     }
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" = var.submit_max_scale
-      }
+
+        "run.googleapis.com/sandbox" = "gvisor"
+      }, var.submit_annotations)
     }
   }
 
@@ -90,9 +92,11 @@ resource "google_cloud_run_service" "visit" {
       service_account_name  = google_service_account.visit.account_id
     }
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" = var.visit_max_scale
-      }
+
+        "run.googleapis.com/sandbox" = "gvisor"
+      }, var.visit_annotations)
     }
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,9 @@ output "submit_url" {
   value       = google_cloud_run_service.submit.status[0].url
   description = "Public Cloud Run URL for submissions"
 }
+output "submit_name" {
+  value = google_cloud_run_service.submit.name
+}
+output "submit_id" {
+  value = google_cloud_run_service.submit.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,8 +3,10 @@ output "submit_url" {
   description = "Public Cloud Run URL for submissions"
 }
 output "submit_name" {
-  value = google_cloud_run_service.submit.name
+  value       = google_cloud_run_service.submit.name
+  description = "Name of Cloud Run service for submissions"
 }
 output "submit_id" {
-  value = google_cloud_run_service.submit.id
+  value       = google_cloud_run_service.submit.id
+  description = "ID of Cloud Run service for submissions"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,13 @@ variable "visit_max_scale" {
   default     = 10
   description = "Maximum concurrent visit instances"
 }
+variable "submit_annotations" {
+  type        = map(string)
+  default     = {}
+  description = "Additional annotations to apply to submit instances"
+}
+variable "visit_annotations" {
+  type        = map(string)
+  default     = {}
+  description = "Additional annotations to apply to visit instances"
+}


### PR DESCRIPTION
Add variable for setting additional annotations on both cloud run services. Also adds the `sandbox` annotation to the spec to avoid noise in plans.
